### PR TITLE
fix: correct Italian grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # openai-test
-Progetto di test per ambiente Codex con accesso GitHub.
+Progetto di test per ambiente Codex con accesso a GitHub.


### PR DESCRIPTION
## Summary
- correct Italian phrase to read "accesso a GitHub"

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689509aa30008324852960510a28e18d